### PR TITLE
Feat/更新 Nginx 配置以支持多入口映射

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,13 +51,16 @@ SUB_STORE_ADMIN_TLS_CERT_PATH=/certs/admin.crt
 SUB_STORE_ADMIN_TLS_KEY_PATH=/certs/admin.key
 
 # 公网订阅入口配置：只有你需要从公网访问你的订阅时才需要
-# 订阅文件在公网暴露的路径
-SUB_STORE_FEED_PUBLIC_PATH=/yew-rhizome
-# 订阅文件在 sub-store 后端的路径
-SUB_STORE_FEED_UPSTREAM_PATH=/backend/api/file/yew-rhizome
+# 多路由 share 透传：只把 token 传给后端，其它 query 一律丢弃
+# 格式：/公网路径|sub/col/file|资源名|目标平台(可选, 仅 sub/col 支持)
+# 资源名和目标平台如有空格、中文或特殊字符，请先 URL 编码
+# 例子：
+# SUB_STORE_FEED_ROUTES=/phone|file|yew-rhizome;/ipad|sub|airport|ClashMeta;/mac|col|airport-rhizome|Surge
+# 对应公网链接示例：
+# https://sub-feed.example.com/phone?token=<后端签发的 share token>
+SUB_STORE_FEED_ROUTES=
+
 # 公网域名名称
 SUB_STORE_FEED_SERVER_NAME=sub-feed.example.com
-# 校验 token 值
-SUB_STORE_FEED_TOKEN=change-me
 # Cloudflare Tunnel Token
 CLOUDFLARED_TUNNEL_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ FRONTEND_PUBLIC_PATH=/
 SUB_STORE_FRONTEND_BACKEND_PATH=/backend
 
 # 主服务镜像名称
-SUB_STORE_IMAGE=ghcr.io/yewfence/sub-store:latest
+SUB_STORE_IMAGE=ghcr.io/yewfence/sub-store-image:latest
 
 # 管理页面入口：建议绑定到宿主机的 Tailscale IP
 TS_BIND_IP=

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+deploy/**/*.tmpl linguist-language=Nginx

--- a/README.md
+++ b/README.md
@@ -49,13 +49,15 @@ cp .env.example .env
 
 ```bash
 docker compose pull sub-store
-docker compose up -d --build
+# proxy 服务用官方 nginx 镜像，通过挂载脚本在启动时注入配置
+docker compose up -d
 ```
 
 如果想用 Cloudflare Tunnel 让订阅可以在公网访问，先确保 `.env` 里`公网订阅入口配置`那部分填好了，然后启用 `public` profile：
 
 ```bash
-docker compose --profile public up -d --build
+# proxy 服务用官方 nginx 镜像，通过挂载脚本在启动时注入配置
+docker compose --profile public up -d
 ```
 
 #### 本地开发

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,9 +12,9 @@ services:
     networks:
       - sub-store-internal
 
+  # 该服务预设了简单的反向代理配置，也可以注释/删除以下服务并自行配置其他反向代理服务并将上游地址指向 sub-store:3000 来访问后端服务。
   admin-proxy:
-    build:
-      context: ./deploy/admin-proxy
+    image: nginx:1.28-alpine
     container_name: sub-store-admin-proxy
     restart: unless-stopped
     depends_on:
@@ -30,12 +30,14 @@ services:
       - "${TS_BIND_IP:-127.0.0.1}:${SUB_STORE_ADMIN_HTTPS_PORT:-38443}:443"
     volumes:
       - ./certs:/certs:ro
+      - ./deploy/admin-proxy/docker-entrypoint.sh:/docker-entrypoint.d/40-sub-store-config.sh:ro
+      - ./deploy/admin-proxy/default.conf.tmpl:/etc/sub-store/default.conf.tmpl:ro
+      - ./deploy/admin-proxy/tls-server.conf.tmpl:/etc/sub-store/tls-server.conf.tmpl:ro
     networks:
       - sub-store-internal
 
   feed-proxy:
-    build:
-      context: ./deploy/feed-proxy
+    image: nginx:1.28-alpine
     container_name: sub-store-feed-proxy
     restart: unless-stopped
     depends_on:
@@ -47,6 +49,9 @@ services:
       FEED_PUBLIC_PATH: ${SUB_STORE_FEED_PUBLIC_PATH:-/yew-rhizome}
       FEED_TOKEN: ${SUB_STORE_FEED_TOKEN:-}
       FEED_UPSTREAM: http://sub-store:3000${SUB_STORE_FEED_UPSTREAM_PATH:-/backend/api/file/yew-rhizome}
+    volumes:
+      - ./deploy/feed-proxy/docker-entrypoint.sh:/docker-entrypoint.d/40-sub-store-config.sh:ro
+      - ./deploy/feed-proxy/default.conf.tmpl:/etc/sub-store/default.conf.tmpl:ro
     networks:
       - sub-store-internal
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
   sub-store:
     env_file:
       - .env
-    image: ${SUB_STORE_IMAGE:-ghcr.io/yewfence/sub-store:latest}
+    image: ${SUB_STORE_IMAGE:-ghcr.io/yewfence/sub-store-image:latest}
     container_name: sub-store
     restart: unless-stopped
     expose:

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,9 +46,7 @@ services:
       - public
     environment:
       FEED_SERVER_NAME: ${SUB_STORE_FEED_SERVER_NAME:-_}
-      FEED_PUBLIC_PATH: ${SUB_STORE_FEED_PUBLIC_PATH:-/yew-rhizome}
-      FEED_TOKEN: ${SUB_STORE_FEED_TOKEN:-}
-      FEED_UPSTREAM: http://sub-store:3000${SUB_STORE_FEED_UPSTREAM_PATH:-/backend/api/file/yew-rhizome}
+      FEED_ROUTES: ${SUB_STORE_FEED_ROUTES:-}
     volumes:
       - ./deploy/feed-proxy/docker-entrypoint.sh:/docker-entrypoint.d/40-sub-store-config.sh:ro
       - ./deploy/feed-proxy/default.conf.tmpl:/etc/sub-store/default.conf.tmpl:ro

--- a/deploy/admin-proxy/Dockerfile
+++ b/deploy/admin-proxy/Dockerfile
@@ -1,9 +1,0 @@
-FROM nginx:1.28-alpine
-
-COPY docker-entrypoint.sh /docker-entrypoint-local.sh
-COPY default.conf.tmpl /etc/sub-store/default.conf.tmpl
-COPY tls-server.conf.tmpl /etc/sub-store/tls-server.conf.tmpl
-
-RUN chmod +x /docker-entrypoint-local.sh
-
-CMD ["/docker-entrypoint-local.sh"]

--- a/deploy/admin-proxy/docker-entrypoint.sh
+++ b/deploy/admin-proxy/docker-entrypoint.sh
@@ -26,6 +26,5 @@ if [ "${enable_tls}" = "true" ]; then
     export ADMIN_TLS_SERVER_BLOCK
 fi
 
+# 显式指定变量列表，避免 nginx 原生变量（$host、$remote_addr 等）被误替换
 envsubst '${ADMIN_SERVER_NAME} ${ADMIN_UPSTREAM} ${ADMIN_TLS_SERVER_BLOCK}' < "${main_template}" > "${conf_path}"
-
-exec nginx -g 'daemon off;'

--- a/deploy/feed-proxy/Dockerfile
+++ b/deploy/feed-proxy/Dockerfile
@@ -1,8 +1,0 @@
-FROM nginx:1.28-alpine
-
-COPY docker-entrypoint.sh /docker-entrypoint-local.sh
-COPY default.conf.tmpl /etc/sub-store/default.conf.tmpl
-
-RUN chmod +x /docker-entrypoint-local.sh
-
-CMD ["/docker-entrypoint-local.sh"]

--- a/deploy/feed-proxy/default.conf.tmpl
+++ b/deploy/feed-proxy/default.conf.tmpl
@@ -8,25 +8,7 @@ server {
         return 200 'ok';
     }
 
-    location = ${FEED_PUBLIC_PATH} {
-        limit_except GET HEAD {
-            deny all;
-        }
-
-        if ($arg_token != "${FEED_TOKEN}") {
-            return 403;
-        }
-
-        add_header Cache-Control "no-store" always;
-        proxy_pass ${FEED_UPSTREAM}?;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 300s;
-        proxy_send_timeout 300s;
-    }
+${FEED_LOCATION_BLOCKS}
 
     location / {
         return 404;

--- a/deploy/feed-proxy/docker-entrypoint.sh
+++ b/deploy/feed-proxy/docker-entrypoint.sh
@@ -22,18 +22,20 @@ require_absolute_path() {
 }
 
 require_clean_path() {
+    # Allowlist: alphanumeric, '/', '.', '-', '_', '~', '%'
     case "$1" in
-        *' '*|*'	'*|*'?'*|*'#'*)
-            echo "$2 contains unsupported characters: $1" >&2
+        *[!A-Za-z0-9/._~%-]*)
+            echo "$2 contains unsupported characters (only A-Za-z0-9/._~%- are allowed): $1" >&2
             exit 1
             ;;
     esac
 }
 
 require_clean_segment() {
+    # Allowlist: alphanumeric, '.', '-', '_', '~', '%' (no slash)
     case "$1" in
-        *' '*|*'	'*|*'/'*|*'?'*|*'#'*)
-            echo "$2 contains unsupported characters: $1" >&2
+        *[!A-Za-z0-9._~%-]*)
+            echo "$2 contains unsupported characters (only A-Za-z0-9._~%- are allowed): $1" >&2
             echo "$2 如需包含特殊字符，请先做 URL 编码" >&2
             exit 1
             ;;

--- a/deploy/feed-proxy/docker-entrypoint.sh
+++ b/deploy/feed-proxy/docker-entrypoint.sh
@@ -24,7 +24,7 @@ require_absolute_path() {
 require_clean_path() {
     # Allowlist: alphanumeric, '/', '.', '-', '_', '~', '%'
     case "$1" in
-        *[!A-Za-z0-9/._~%-]*)
+        *[!-A-Za-z0-9/._~%]*)
             echo "$2 contains unsupported characters (only A-Za-z0-9/._~%- are allowed): $1" >&2
             exit 1
             ;;
@@ -34,7 +34,7 @@ require_clean_path() {
 require_clean_segment() {
     # Allowlist: alphanumeric, '.', '-', '_', '~', '%' (no slash)
     case "$1" in
-        *[!A-Za-z0-9._~%-]*)
+        *[!-A-Za-z0-9._~%]*)
             echo "$2 contains unsupported characters (only A-Za-z0-9._~%- are allowed): $1" >&2
             echo "$2 如需包含特殊字符，请先做 URL 编码" >&2
             exit 1

--- a/deploy/feed-proxy/docker-entrypoint.sh
+++ b/deploy/feed-proxy/docker-entrypoint.sh
@@ -2,29 +2,186 @@
 set -eu
 
 server_name="${FEED_SERVER_NAME:-_}"
-public_path="${FEED_PUBLIC_PATH:-/yew-rhizome}"
-upstream="${FEED_UPSTREAM:-http://sub-store:3000/backend/api/file/yew-rhizome}"
-token="${FEED_TOKEN:-}"
+routes="${FEED_ROUTES:-}"
 conf_path="/etc/nginx/conf.d/default.conf"
 template_path="/etc/sub-store/default.conf.tmpl"
+blocks_file="/tmp/feed-location-blocks.conf"
 
-if [ -z "${token}" ]; then
-    echo "FEED_TOKEN is required for feed-proxy" >&2
+trim() {
+    printf '%s' "$1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+require_absolute_path() {
+    case "$1" in
+        /*) ;;
+        *)
+            echo "$2 must start with /" >&2
+            exit 1
+            ;;
+    esac
+}
+
+require_clean_path() {
+    case "$1" in
+        *' '*|*'	'*|*'?'*|*'#'*)
+            echo "$2 contains unsupported characters: $1" >&2
+            exit 1
+            ;;
+    esac
+}
+
+require_clean_segment() {
+    case "$1" in
+        *' '*|*'	'*|*'/'*|*'?'*|*'#'*)
+            echo "$2 contains unsupported characters: $1" >&2
+            echo "$2 如需包含特殊字符，请先做 URL 编码" >&2
+            exit 1
+            ;;
+    esac
+}
+
+normalize_type() {
+    case "$1" in
+        sub|subscription)
+            printf 'sub'
+            ;;
+        col|collection)
+            printf 'col'
+            ;;
+        file)
+            printf 'file'
+            ;;
+        *)
+            echo "Unsupported feed route type: $1" >&2
+            exit 1
+            ;;
+    esac
+}
+
+append_common_proxy_directives() {
+    cat >>"${blocks_file}" <<'EOF'
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+EOF
+}
+
+append_share_location() {
+    route_public_path="$1"
+    route_type="$2"
+    route_name="$3"
+    route_target="$4"
+    route_upstream="http://sub-store:3000/share/${route_type}/${route_name}"
+
+    if [ -n "${route_target}" ]; then
+        route_upstream="${route_upstream}/${route_target}"
+    fi
+
+    cat >>"${blocks_file}" <<EOF
+    location = ${route_public_path} {
+        limit_except GET HEAD {
+            deny all;
+        }
+
+        if (\$arg_token = "") {
+            return 401;
+        }
+
+        add_header Cache-Control "no-store" always;
+        proxy_pass ${route_upstream}?token=\$arg_token;
+EOF
+    append_common_proxy_directives
+    cat >>"${blocks_file}" <<'EOF'
+    }
+EOF
+}
+
+: >"${blocks_file}"
+
+if [ -z "${routes}" ]; then
+    echo "FEED_ROUTES is required for feed-proxy" >&2
+    echo "Expected format: /public-path|sub|name|target(optional)" >&2
     exit 1
 fi
 
-case "${public_path}" in
-    /*) ;;
-    *)
-        echo "FEED_PUBLIC_PATH must start with /" >&2
+seen_public_paths='|'
+route_count=0
+old_ifs="${IFS}"
+IFS=';'
+for raw_entry in ${routes}; do
+    entry="$(trim "${raw_entry}")"
+    if [ -z "${entry}" ]; then
+        continue
+    fi
+
+    route_public_path=''
+    route_type=''
+    route_name=''
+    route_target=''
+    route_extra=''
+    IFS='|' read -r route_public_path route_type route_name route_target route_extra <<EOF
+${entry}
+EOF
+    IFS=';'
+
+    route_public_path="$(trim "${route_public_path}")"
+    route_type="$(trim "${route_type}")"
+    route_name="$(trim "${route_name}")"
+    route_target="$(trim "${route_target}")"
+    route_extra="$(trim "${route_extra}")"
+
+    if [ -n "${route_extra}" ]; then
+        echo "Invalid FEED_ROUTES entry: ${entry}" >&2
+        echo "Expected format: /public-path|sub|name|target(optional)" >&2
         exit 1
-        ;;
-esac
+    fi
+
+    if [ -z "${route_public_path}" ] || [ -z "${route_type}" ] || [ -z "${route_name}" ]; then
+        echo "Invalid FEED_ROUTES entry: ${entry}" >&2
+        echo "Expected format: /public-path|sub|name|target(optional)" >&2
+        exit 1
+    fi
+
+    require_absolute_path "${route_public_path}" "FEED_ROUTES public path"
+    require_clean_path "${route_public_path}" "FEED_ROUTES public path"
+    require_clean_segment "${route_name}" "FEED_ROUTES resource name"
+    if [ -n "${route_target}" ]; then
+        require_clean_segment "${route_target}" "FEED_ROUTES target"
+    fi
+
+    route_type="$(normalize_type "${route_type}")"
+    if [ "${route_type}" = "file" ] && [ -n "${route_target}" ]; then
+        echo "FEED_ROUTES target is only supported for sub/col routes: ${entry}" >&2
+        exit 1
+    fi
+
+    case "${seen_public_paths}" in
+        *"|${route_public_path}|"*)
+            echo "Duplicated FEED_ROUTES public path: ${route_public_path}" >&2
+            exit 1
+            ;;
+    esac
+    seen_public_paths="${seen_public_paths}${route_public_path}|"
+
+    append_share_location \
+        "${route_public_path}" \
+        "${route_type}" \
+        "${route_name}" \
+        "${route_target}"
+    route_count=$((route_count + 1))
+done
+IFS="${old_ifs}"
+if [ "${route_count}" -eq 0 ]; then
+    echo "FEED_ROUTES is set but contains no valid entries" >&2
+    exit 1
+fi
 
 export FEED_SERVER_NAME="${server_name}"
-export FEED_PUBLIC_PATH="${public_path}"
-export FEED_TOKEN="${token}"
-export FEED_UPSTREAM="${upstream}"
+export FEED_LOCATION_BLOCKS="$(cat "${blocks_file}")"
 
 # 显式指定变量列表，避免 nginx 原生变量（$host、$remote_addr 等）被误替换
-envsubst '${FEED_SERVER_NAME} ${FEED_PUBLIC_PATH} ${FEED_TOKEN} ${FEED_UPSTREAM}' < "${template_path}" > "${conf_path}"
+envsubst '${FEED_SERVER_NAME} ${FEED_LOCATION_BLOCKS}' < "${template_path}" > "${conf_path}"

--- a/deploy/feed-proxy/docker-entrypoint.sh
+++ b/deploy/feed-proxy/docker-entrypoint.sh
@@ -114,6 +114,7 @@ seen_public_paths='|'
 route_count=0
 old_ifs="${IFS}"
 IFS=';'
+set -f
 for raw_entry in ${routes}; do
     entry="$(trim "${raw_entry}")"
     if [ -z "${entry}" ]; then
@@ -176,6 +177,7 @@ EOF
         "${route_target}"
     route_count=$((route_count + 1))
 done
+set +f
 IFS="${old_ifs}"
 if [ "${route_count}" -eq 0 ]; then
     echo "FEED_ROUTES is set but contains no valid entries" >&2

--- a/deploy/feed-proxy/docker-entrypoint.sh
+++ b/deploy/feed-proxy/docker-entrypoint.sh
@@ -151,6 +151,12 @@ EOF
 
     require_absolute_path "${route_public_path}" "FEED_ROUTES public path"
     require_clean_path "${route_public_path}" "FEED_ROUTES public path"
+    case "${route_public_path}" in
+        /healthz|/)
+            echo "FEED_ROUTES public path is reserved: ${route_public_path}" >&2
+            exit 1
+            ;;
+    esac
     require_clean_segment "${route_name}" "FEED_ROUTES resource name"
     if [ -n "${route_target}" ]; then
         require_clean_segment "${route_target}" "FEED_ROUTES target"

--- a/deploy/feed-proxy/docker-entrypoint.sh
+++ b/deploy/feed-proxy/docker-entrypoint.sh
@@ -26,6 +26,5 @@ export FEED_PUBLIC_PATH="${public_path}"
 export FEED_TOKEN="${token}"
 export FEED_UPSTREAM="${upstream}"
 
+# 显式指定变量列表，避免 nginx 原生变量（$host、$remote_addr 等）被误替换
 envsubst '${FEED_SERVER_NAME} ${FEED_PUBLIC_PATH} ${FEED_TOKEN} ${FEED_UPSTREAM}' < "${template_path}" > "${conf_path}"
-
-exec nginx -g 'daemon off;'


### PR DESCRIPTION
常见的使用场景为多部设备需要不同配置的订阅，如移动端设备需要特别的 Tailscale 节点，或者 Mihomo 格式与 Apple 的 SS 应用不兼容导致需要两个配置的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feed proxy configuration now uses routing-based setup via `FEED_ROUTES` environment variable (replaces individual path, token, and upstream settings).

* **Chores**
  * Updated Docker image reference for sub-store service.
  * Simplified deployment process; `--build` flag removed from startup commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->