### PR TITLE
feat(ci): add scheduled Renovate dashboard trigger workflow

### DIFF
--- a/.github/workflows/renovate-dashboard-trigger.yml
+++ b/.github/workflows/renovate-dashboard-trigger.yml
@@ -30,7 +30,6 @@ jobs:
             const targetText = process.env.TARGET_TEXT;
 
             const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            const uncheckedLine = `- [ ] <!-- manual job -->${targetText}`;
             const checkedLine = `- [x] <!-- manual job -->${targetText}`;
             const checkboxPattern = new RegExp(
               `- \\[[ xX]\\] <!-- manual job -->${escapeRegExp(targetText)}`
@@ -52,24 +51,14 @@ jobs:
               return;
             }
 
-            if (matchedLine !== uncheckedLine) {
-              const resetBody = originalBody.replace(checkboxPattern, uncheckedLine);
-
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                body: resetBody,
-              });
-
-              core.info(`Reset checkbox in issue #${issueNumber} to unchecked.`);
+            if (matchedLine === checkedLine) {
+              core.info(
+                `Checkbox in issue #${issueNumber} is already checked; Renovate will handle unchecking. Skipping.`
+              );
+              return;
             }
 
-            const latestBody =
-              matchedLine === uncheckedLine
-                ? originalBody
-                : originalBody.replace(checkboxPattern, uncheckedLine);
-            const nextBody = latestBody.replace(uncheckedLine, checkedLine);
+            const nextBody = originalBody.replace(checkboxPattern, checkedLine);
 
             await github.rest.issues.update({
               owner: context.repo.owner,

--- a/.github/workflows/renovate-dashboard-trigger.yml
+++ b/.github/workflows/renovate-dashboard-trigger.yml
@@ -1,0 +1,81 @@
+name: Trigger Renovate Dashboard
+
+on:
+  # Renovate Cloud treats branch-automerge repositories like this one as
+  # "onboarded" instead of "activated", so the default run cadence stays daily.
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: renovate-dashboard-trigger
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Toggle Dependency Dashboard rerun checkbox
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: "2"
+          TARGET_TEXT: "Check this box to trigger a request for Renovate to run again on this repository"
+        with:
+          script: |
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const targetText = process.env.TARGET_TEXT;
+
+            const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const uncheckedLine = `- [ ] <!-- manual job -->${targetText}`;
+            const checkedLine = `- [x] <!-- manual job -->${targetText}`;
+            const checkboxPattern = new RegExp(
+              `- \\[[ xX]\\] <!-- manual job -->${escapeRegExp(targetText)}`
+            );
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+
+            const originalBody = issue.body ?? '';
+            const matchedLine = originalBody.match(checkboxPattern)?.[0];
+
+            if (!matchedLine) {
+              core.setFailed(
+                `Could not find the Renovate rerun checkbox in issue #${issueNumber}.`
+              );
+              return;
+            }
+
+            if (matchedLine !== uncheckedLine) {
+              const resetBody = originalBody.replace(checkboxPattern, uncheckedLine);
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: resetBody,
+              });
+
+              core.info(`Reset checkbox in issue #${issueNumber} to unchecked.`);
+            }
+
+            const latestBody =
+              matchedLine === uncheckedLine
+                ? originalBody
+                : originalBody.replace(checkboxPattern, uncheckedLine);
+            const nextBody = latestBody.replace(uncheckedLine, checkedLine);
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: nextBody,
+            });
+
+            core.info(`Checked the Renovate rerun checkbox in issue #${issueNumber}.`);

--- a/README.md
+++ b/README.md
@@ -199,12 +199,14 @@ just publish-push ghcr.io/your-name/sub-store
 
 ### 自动化流程
 
-有两条工作流：
+有三条工作流：
 
 - [`Upstream Smoke`](./.github/workflows/upstream-smoke.yml)
   监听 `renovate/**` 分支。Renovate 更新锁文件后，这条工作流会拉上游源码、构建镜像、跑前后端测试。作为测试，通过配置 Renovate 的自动合并以自动更新 `main` 分支
 - [`Publish Image`](./.github/workflows/publish.yml)
   监听 `main` 分支。`main` 有更新时发布 GHCR 镜像并创建 GitHub Release。
+- [`Trigger Renovate Dashboard`](./.github/workflows/renovate-dashboard-trigger.yml)
+  每 4 小时把 Renovate Dependency Dashboard(issue #2) 里的 `manual job` checkbox 勾上一次，用来主动触发新一轮 Renovate 运行。
 
 ### 镜像 tag 规则
 

--- a/docs/github-actions-setup.md
+++ b/docs/github-actions-setup.md
@@ -6,13 +6,14 @@
 
 配置完成后，链路会是这样：
 
-1. Renovate 发现上游 release/tag 更新
-2. Renovate 更新 [`sources.lock.json`](../sources.lock.json)
-3. `renovate/**` 分支触发 [`Upstream Smoke`](../.github/workflows/upstream-smoke.yml)
-4. 冒烟通过后 Renovate 把更新直接写入 `main`(默认不会开 PR)
-5. `main` 提交触发 [`Publish Image`](../.github/workflows/publish.yml)
-6. 工作流把镜像推到 GHCR
-7. 工作流创建或更新这个仓库自己的 GitHub Release
+1. [`Trigger Renovate Dashboard`](../.github/workflows/renovate-dashboard-trigger.yml) 每 4 小时勾一次 Renovate Dependency Dashboard(issue #2) 里的 `manual job` checkbox
+2. Renovate 发现上游 release/tag 更新
+3. Renovate 更新 [`sources.lock.json`](../sources.lock.json)
+4. `renovate/**` 分支触发 [`Upstream Smoke`](../.github/workflows/upstream-smoke.yml)
+5. 冒烟通过后 Renovate 把更新直接写入 `main`(默认不会开 PR)
+6. `main` 提交触发 [`Publish Image`](../.github/workflows/publish.yml)
+7. 工作流把镜像推到 GHCR
+8. 工作流创建或更新这个仓库自己的 GitHub Release
 
 ## TL;DR
 
@@ -126,3 +127,23 @@
 - 确认 `main` 的分支保护策略和 `automergeType=branch` 不冲突
 - 手动触发一次 `Upstream Smoke`
 - 手动触发一次 `Publish Image`
+
+## 9. 定时触发 Renovate
+
+仓库内置了 [`Trigger Renovate Dashboard`](../.github/workflows/renovate-dashboard-trigger.yml)：
+
+- 触发频率：每 4 小时一次
+- 触发方式：编辑 issue `#2`，只把这一行 checkbox 改成勾选状态
+- 目标行：`- [ ] <!-- manual job -->Check this box to trigger a request for Renovate to run again on this repository`
+
+这样做的目的是兼容 Renovate Dependency Dashboard 现有的手动 rerun 入口。
+
+补充背景：
+
+- Renovate 官方 cloud 对这种“直接往分支提交并自动合并、而不是走 PR 合并”的仓库，状态通常只算 `onboarded`，不是 `activated`
+- 在这个状态下，Renovate 默认扫描频率通常是每天一次，不是 `activated` 常见的每 4 小时一次
+- 官方也没有提供一个稳定可用的 API 端点来直接触发 cloud 立即重跑
+
+因此这里选择用 GitHub Actions 定时去勾 dashboard 里的 `manual job` checkbox，等价于把原本的手工 rerun 自动化。
+
+如果以后 dashboard 里新增其他 checkbox，这个 workflow 不会碰它们；它只匹配 `manual job` 这一行固定文案。

--- a/docs/github-actions-setup.md
+++ b/docs/github-actions-setup.md
@@ -144,6 +144,6 @@
 - 在这个状态下，Renovate 默认扫描频率通常是每天一次，不是 `activated` 常见的每 4 小时一次
 - 官方也没有提供一个稳定可用的 API 端点来直接触发 cloud 立即重跑
 
-因此这里选择用 GitHub Actions 定时去勾 dashboard 里的 `manual job` checkbox，等价于把原本的手工 rerun 自动化。
+因此这里选择用 GitHub Actions 定时勾选 dashboard 里的 manual job checkbox，等价于把原本的手工 rerun 自动化。
 
 如果以后 dashboard 里新增其他 checkbox，这个 workflow 不会碰它们；它只匹配 `manual job` 这一行固定文案。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated workflow to trigger Renovate dependency updates every 4 hours, enabling more frequent checks for dependency updates without manual intervention.

* **Documentation**
  * Updated README and documentation to describe the new automated Renovate trigger workflow and its scheduling cadence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->